### PR TITLE
Factorio object definition has changed

### DIFF
--- a/stdlib/utils/is.lua
+++ b/stdlib/utils/is.lua
@@ -353,7 +353,7 @@ M.alphanumword = M.AlphanumWord
 -- @tparam LuaObject var The variable to check
 -- @treturn mixed the var if this is an LuaObject
 function M.Object(var)
-    return M.Table(var) and var.__self and var
+    return M.Userdata(var) and var
 end
 M.object = M.Object
 


### PR DESCRIPTION
from the 2.0.7 changelog:

* Type of LuaObjects is now "userdata" instead of "table".
* Removed __self from the LuaObjects. Intended way of checking if an object is a lua object is to check type is userdata.

Without this change, e.g. Is.Valid does not work.